### PR TITLE
Revert "TP GitHub - Hernán Lovera"

### DIFF
--- a/Hernan-Lovera/archivo.txt
+++ b/Hernan-Lovera/archivo.txt
@@ -1,4 +1,0 @@
-Nombre: Ricardo Hernán
-Apellido: Lovera
-DNI: 45.135.060
-Telefono: 3764211364


### PR DESCRIPTION
Tengo que revertir el cambio de aceptación de la PR porque no se tiene que incluir lo del 2do commit ya que es la carpeta del repositorio en sí misma.

El primer commit sí está bien porque tiene la carpeta con su nombre-apellido y el archivo de datos.

Se sugiere corregir eso del segundo commit y voler a actualizar la PR.